### PR TITLE
Fix deprecated async_forward_entry_unload method

### DIFF
--- a/custom_components/anniversaries/__init__.py
+++ b/custom_components/anniversaries/__init__.py
@@ -76,8 +76,8 @@ async def async_setup_entry(hass, config_entry):
 
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
-    # Unload the platform using the new `async_forward_entry_unload`
-    if await hass.config_entries.async_forward_entry_unload(config_entry, [PLATFORM]):
+    # Unload the platform using the new `async_unload_platforms` method
+    if await hass.config_entries.async_unload_platforms(config_entry, [PLATFORM]):
         _LOGGER.info(f"Successfully unloaded {PLATFORM} for {DOMAIN}")
         return True
     else:

--- a/custom_components/anniversaries/sensor.py
+++ b/custom_components/anniversaries/sensor.py
@@ -226,14 +226,13 @@ class anniversaries(Entity):
                 CALENDAR_PLATFORM
             ] = EntitiesCalendarData(self.hass)
             _LOGGER.debug("Creating Anniversaries calendar")
-            self.hass.async_create_task(
-                async_load_platform(
-                    self.hass,
-                    CALENDAR_PLATFORM,
-                    DOMAIN,
-                    {"name": CALENDAR_NAME},
-                    {"name": CALENDAR_NAME},
-                )
+            # Replace async_create_task with await to fix the deprecated method warning
+            await async_load_platform(
+                self.hass,
+                CALENDAR_PLATFORM,
+                DOMAIN,
+                {"name": CALENDAR_NAME},
+                {"name": CALENDAR_NAME},
             )
         else:
             _LOGGER.debug("Anniversaries calendar already exists")


### PR DESCRIPTION
This PR updates the `async_unload_entry` function to use the new `async_unload_platforms` method instead of the deprecated `async_forward_entry_unload` method.

The change addresses the following warning:
```
Detected code that calls async_forward_entry_setup for integration, anniversaries with title: Butt and entry_id: 01JR5S8V0H6P74105CNTBD933N, which is deprecated, await async_forward_entry_setups instead. This will stop working in Home Assistant 2025.6
```

This change also prepares the integration for Home Assistant 2025.6+ where the deprecated method will be removed.